### PR TITLE
[RTL] Fix Phy FSM: add a parameter t_csh to delay the CSn posedge

### DIFF
--- a/src/hyperbus_cfg_regs.sv
+++ b/src/hyperbus_cfg_regs.sv
@@ -28,7 +28,7 @@ module hyperbus_cfg_regs #(
     `include "common_cells/registers.svh"
 
     // Internal Parameters
-    localparam int unsigned NumBaseRegs     = 10;
+    localparam int unsigned NumBaseRegs     = 11;
     localparam int unsigned NumRegs         = 2*NumChips + NumBaseRegs;
     localparam int unsigned RegsBits        = cf_math_pkg::idx_width(NumRegs);
     localparam int unsigned RegStrbWidth    = RegDataWidth/8;                   // TODO ASSERT: Must be power of two >= 16!!
@@ -57,6 +57,7 @@ module hyperbus_cfg_regs #(
         if (sel_reg_mapped) begin
             rfield = {
                 crange_q,
+                reg_data_t'(cfg_q.t_csh_cycles),
                 reg_data_t'(cfg_q.which_phy),
                 reg_data_t'(cfg_q.phys_in_use),
                 reg_data_t'(cfg_q.address_space),
@@ -95,6 +96,7 @@ module hyperbus_cfg_regs #(
                 'h7: cfg_d.address_space            = (~wmask & cfg_q.address_space           ) | (wmask & reg_req_i.wdata);
                 'h8: cfg_d.phys_in_use              = (NumPhys==1) ? 0 : ( (~wmask & cfg_q.phys_in_use ) | (wmask & reg_req_i.wdata) );
                 'h9: cfg_d.which_phy                = (NumPhys==1) ? 0 : ( (~wmask & cfg_q.which_phy   ) | (wmask & reg_req_i.wdata) );
+                'ha: cfg_d.t_csh_cycles             = (~wmask & cfg_q.t_csh_cycles            ) | (wmask & reg_req_i.wdata);
                 default: begin
                     {sel_chip, chip_reg} = sel_reg - NumBaseRegs;
                     crange_d[sel_chip][chip_reg] = (~wmask & crange_q[sel_chip][chip_reg]) |  (wmask & reg_req_i.wdata);
@@ -114,7 +116,8 @@ module hyperbus_cfg_regs #(
         address_mask_msb:           'd25,       // 26 bit addresses = 2^6*2^20B == 64 MB per chip (biggest availale as of now)
         address_space:              'b0,
         phys_in_use:                NumPhys-1,
-        which_phy:                  NumPhys-1
+        which_phy:                  NumPhys-1,
+        t_csh_cycles:               'h1
     };
 
     for (genvar i = 0; unsigned'(i) < NumChips; i++) begin : gen_crange_rstval

--- a/src/hyperbus_phy.sv
+++ b/src/hyperbus_phy.sv
@@ -321,11 +321,13 @@ module hyperbus_phy import hyperbus_pkg::*; #(
                     tf_d.burst      = tf_q.burst - phys_in_use;
                     tf_d.address    = tf_q.address + 1;
                     if (ctl_tf_burst_last) begin
+                        timer_d = cfg_i.t_csh_cycles;
                         state_d = WaitXfer;
                     end
                 end
                 // Force-terminate access on burst time limit
                 if (ctl_timer_one) begin
+                    timer_d = cfg_i.t_csh_cycles;
                     state_d = WaitXfer;
                 end
             end
@@ -341,19 +343,23 @@ module hyperbus_phy import hyperbus_pkg::*; #(
                     tf_d.address    = tf_q.address + 1;
                     if (ctl_tf_burst_last) begin
                         b_pending_set   = 1'b1;
+                        timer_d = cfg_i.t_csh_cycles;
                         state_d         = WaitXfer;
                     end
                 end
                 // Force-terminate access on burst time limit
                 if (ctl_timer_one) begin
+                    timer_d = cfg_i.t_csh_cycles;
                     state_d = WaitXfer;
                 end
             end
             WaitXfer: begin
                 // Wait for FFed Clock and output to stop
                 // May have to be prolonged for potential future devices with t_CSH > 0
-                timer_d = cfg_i.t_read_write_recovery;
-                state_d = WaitRWR;
+                if (ctl_timer_zero) begin
+                    timer_d = cfg_i.t_read_write_recovery;
+                    state_d = WaitRWR;
+                end
             end
             WaitRWR: begin
                 trx_cs_ena = 1'b0;

--- a/src/hyperbus_pkg.sv
+++ b/src/hyperbus_pkg.sv
@@ -20,6 +20,7 @@ package hyperbus_pkg;
         logic           address_space;
         logic           phys_in_use;
         logic           which_phy;
+        logic [3:0]     t_csh_cycles; //add an configurable Tcsh for high freq operation(200MHz Hyperram)
     } hyper_cfg_t;
 
     typedef struct packed {


### PR DESCRIPTION
We meet a problem when trying to run hyperbus with >100MHz (CK, CK# pads): during read transaction,  the CSn signal goes up earlier than the last RWDS negedge come from hyperram, the hyperram model then will not send the RWDS negedge, thus our CDC fifo can not capture the last beat of data, and result in forever stalling

To fix this issue, I first change the FSM that can wait more "t_csh_cycles" before rise up the CSn, and this parameter "t_csh_cycles" is added in cfg_reg, with default value 1, thus we can configure it through regbus.