### PR TITLE
Expose config register reset values as parameter

### DIFF
--- a/src/hyperbus.sv
+++ b/src/hyperbus.sv
@@ -29,8 +29,9 @@ module hyperbus #(
     // The below have sensible defaults, but should be set on integration!
     parameter int unsigned  RxFifoLogDepth  = 2,
     parameter int unsigned  TxFifoLogDepth  = 2,
-    parameter logic [RegDataWidth-1:0] RstChipBase  = 'h0,      // Base address for all chips
-    parameter logic [RegDataWidth-1:0] RstChipSpace = 'h1_0000, // 64 KiB: Current maximum HyperBus device size
+    parameter logic [RegDataWidth-1:0]  RstChipBase  = 'h0,      // Base address for all chips
+    parameter logic [RegDataWidth-1:0]  RstChipSpace = 'h1_0000, // 64 KiB: Current maximum HyperBus device size
+    parameter hyperbus_pkg::hyper_cfg_t RstCfg       = hyperbus_pkg::gen_RstCfg(NumPhys),
     parameter int unsigned  PhyStartupCycles = 300 * 200, /* us*MHz */ // Conservative maximum frequency estimate
     parameter int unsigned  AxiLogDepth = 3,
     parameter int unsigned  SyncStages  = 2
@@ -123,7 +124,8 @@ module hyperbus #(
         .reg_rsp_t      ( reg_rsp_t     ),
         .rule_t         ( axi_rule_t    ),
         .RstChipBase    ( RstChipBase   ),
-        .RstChipSpace   ( RstChipSpace  )
+        .RstChipSpace   ( RstChipSpace  ),
+        .RstCfg         ( RstCfg        )
     ) i_cfg_regs (
         .clk_i          ( clk_sys_i     ),
         .rst_ni         ( rst_sys_ni    ),

--- a/src/hyperbus_pkg.sv
+++ b/src/hyperbus_pkg.sv
@@ -57,4 +57,27 @@ package hyperbus_pkg;
         logic [2:0]     addr_lower;
     } hyper_phy_ca_t;
 
+
+    // Register reset values
+    function hyper_cfg_t gen_RstCfg(input int unsigned NumPhys, input int unsigned MinFreqMhz = 100);
+        // MinFreqMHz = 100 is the spec conform version and should not be changed
+        // It can be lowered if this frequency is not reachable in operation (may not with with certain HyperBus devices)
+        // >200 is outside the spec and is unlikely to work with any HyperBus devices
+        automatic hyper_cfg_t cfg = hyper_cfg_t'{
+            t_latency_access:           'h6,
+            en_latency_additional:      'b0,
+            t_burst_max:                ((MinFreqMhz*35)/10), // t_{csm}: At lowest legal clock (100 MHz) 3.5us (0.5us safety margin)
+            t_read_write_recovery:      'h6,
+            t_rx_clk_delay:             'h8,
+            t_tx_clk_delay:             'h8,
+            address_mask_msb:           'd25,                // 26 bit addresses = 2^6*2^20B == 64 MB per chip (biggest availale as of now)
+            address_space:              'b0,
+            phys_in_use:                NumPhys-1,
+            which_phy:                  NumPhys-1,
+            t_csh_cycles:               'h1
+        };
+
+        return cfg;
+    endfunction
+
 endpackage


### PR DESCRIPTION
By exposing the reset values of the configuration register we can support clock frequencies below spec.

Assertions are placed to warn in case of non-spec conform configurations.