### PR TITLE
Add support for true PHY toggling via software

### DIFF
--- a/src/hyperbus_phy.sv
+++ b/src/hyperbus_phy.sv
@@ -22,6 +22,8 @@ module hyperbus_phy import hyperbus_pkg::*; #(
     input  logic                test_mode_i,
     // Config registers
     input  hyper_cfg_t          cfg_i,
+    // PHY control status
+    output logic                busy_o,
     // Transactions
     input  logic                trans_valid_i,
     output logic                trans_ready_o,
@@ -229,6 +231,8 @@ module hyperbus_phy import hyperbus_pkg::*; #(
     assign ctl_timer_two        = (timer_q == 2);
     assign ctl_timer_one        = (timer_q == 1);
     assign ctl_timer_zero       = (timer_q == 0);
+
+    assign busy_o = (state_q != Idle);
 
     // FSM logic
     always_comb begin : proc_comb_phy_fsm

--- a/test/axi_hyper_tb.sv
+++ b/test/axi_hyper_tb.sv
@@ -177,6 +177,7 @@ module axi_hyper_tb
        $display("===========================");
 
        reg_master.send_write(32'h20,1'b0,'1,s_reg_error);
+       reg_master.send_write(32'h24,1'b0,'1,s_reg_error);
        if (s_reg_error != 1'b0) $error("unexpected error");
 
        axi_master.reset();


### PR DESCRIPTION
The current implementation can be configured via the control registers to logically ignore one of the phys. However, commands are issued on both phys and responses are expected.

This PR goal is to properly disable a phy via software using the already defined control registers.
https://github.com/pulp-platform/hyperbus/blob/d5b0064a0579f1a559f003f94721055d497af51d/src/hyperbus_cfg_regs.sv#L98-L99

The need for such a modification stems from the ongoing debugging of the latest Hyperram FMC Board, where only one phy appears to be responsive.