### PR TITLE
Use phy 0 in the related test when using two phys

### DIFF
--- a/test/axi_hyper_tb.sv
+++ b/test/axi_hyper_tb.sv
@@ -177,6 +177,7 @@ module axi_hyper_tb
        $display("===========================");
 
        reg_master.send_write(32'h20,1'b0,'1,s_reg_error);
+       reg_master.send_write(32'h24,1'b0,'1,s_reg_error);
        if (s_reg_error != 1'b0) $error("unexpected error");
 
        axi_master.reset();


### PR DESCRIPTION
The configuration register used to choose the active PHY when only one out of the two is enabled resets to `NumPhys-1`. If `NumPhys = 2`, then it resets to `1`. Thus, the test of the PHY 0 should also write the respective register to ensure it contains `0`.
https://github.com/pulp-platform/hyperbus/blob/d5b0064a0579f1a559f003f94721055d497af51d/src/hyperbus_pkg.sv#L75