### PR TITLE
Fix download of HyperRAM model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bender
 scripts/compile.tcl
+models/s27ks0641

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ sim_clean:
 models/s27ks0641:
 	mkdir -p $@
 	rm -rf model_tmp && mkdir model_tmp
-	cd model_tmp; wget https://www.infineon.com/dgdl/Infineon-S27KL0641_S27KS0641_VERILOG-SimulationModels-v05_00-EN.zip?fileId=8ac78c8c7d0d8da4017d0f6349a14f68
-	cd model_tmp; mv 'Infineon-S27KL0641_S27KS0641_VERILOG-SimulationModels-v05_00-EN.zip?fileId=8ac78c8c7d0d8da4017d0f6349a14f68' model.zip
+	cd model_tmp; wget --content-disposition "https://www.infineon.com/dgdl/Infineon-S27KL0641_S27KS0641_VERILOG-SimulationModels-v05_00-EN.zip?fileId=8ac78c8c7d0d8da4017d0f6349a14f68&da=t"
+	mv model_tmp/*.zip model_tmp/model.zip
 	cd model_tmp; unzip model.zip
 	cd model_tmp; mv 'S27KL0641 S27KS0641' exe_folder
 	cd model_tmp/exe_folder; unzip S27ks0641.exe

--- a/src/hyperbus_pkg.sv
+++ b/src/hyperbus_pkg.sv
@@ -59,7 +59,7 @@ package hyperbus_pkg;
 
 
     // Register reset values
-    function automatic hyper_cfg_t gen_RstCfg(input int unsigned NumPhys, input int unsigned MinFreqMhz);
+    function automatic hyper_cfg_t gen_RstCfg(input int unsigned NumPhys, input int unsigned MinFreqMhz = 100);
         // MinFreqMHz = 100 is the spec conform version and should not be changed
         // It can be lowered if this frequency is not reachable in operation (may not with with certain HyperBus devices)
         // >200 is outside the spec and is unlikely to work with any HyperBus devices


### PR DESCRIPTION
* Download was broken (due to a change on Infineon side). Triggered on a working `main` of Carfield, as shown [here](https://iis-git.ee.ethz.ch/github-mirror/carfield/-/jobs/1556894) 
* This is fixed now, and the Carfield CI passes again, as shown [here](https://iis-git.ee.ethz.ch/github-mirror/carfield/-/pipelines/98304)

**Note:** The CI(s) above also check elaboration with synopsys DC (intel16) and vivado

### Additional changes
* Add the model folder to `.gitignore`
* Make `gen_RstCfg` in `hyperbus_pkg` `automatic` because a static function definition can't be synthesized by COTS tools like Synopsys DC (tested `2022.03` and `2024.09`)
* **Note:** it appears that assigning a default value to an argument in a function, as done [here](https://github.com/pulp-platform/hyperbus/blob/main/src/hyperbus_pkg.sv#L62), is not supported by some older versions of COTS synthesis tools like DC (tested `2022.03`), while it works fine for newer versions (tested `2024.09`)

---
It would be nice (and better) to check if this change affects elaboration with open-source tools