### PR TITLE
src: Remove default value passed to args in `gen_RstCfg` function

### DIFF
--- a/src/hyperbus_pkg.sv
+++ b/src/hyperbus_pkg.sv
@@ -59,7 +59,7 @@ package hyperbus_pkg;
 
 
     // Register reset values
-    function automatic hyper_cfg_t gen_RstCfg(input int unsigned NumPhys, input int unsigned MinFreqMhz = 100);
+    function automatic hyper_cfg_t gen_RstCfg(input int unsigned NumPhys, input int unsigned MinFreqMhz);
         // MinFreqMHz = 100 is the spec conform version and should not be changed
         // It can be lowered if this frequency is not reachable in operation (may not with with certain HyperBus devices)
         // >200 is outside the spec and is unlikely to work with any HyperBus devices


### PR DESCRIPTION
* This was erroneously re-introduced with the last PR