### PR TITLE
Makefile: Do not check for CA certificate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ sim_clean:
 models/s27ks0641:
 	mkdir -p $@
 	rm -rf model_tmp && mkdir model_tmp
-	cd model_tmp; wget --content-disposition "https://www.infineon.com/dgdl/Infineon-S27KL0641_S27KS0641_VERILOG-SimulationModels-v05_00-EN.zip?fileId=8ac78c8c7d0d8da4017d0f6349a14f68&da=t"
+	cd model_tmp; wget --no-check-certificate --content-disposition "https://www.infineon.com/dgdl/Infineon-S27KL0641_S27KS0641_VERILOG-SimulationModels-v05_00-EN.zip?fileId=8ac78c8c7d0d8da4017d0f6349a14f68&da=t"
 	mv model_tmp/*.zip model_tmp/model.zip
 	cd model_tmp; unzip model.zip
 	cd model_tmp; mv 'S27KL0641 S27KS0641' exe_folder


### PR DESCRIPTION
This prevents download to error out if the certificate changes and a server does not recognize it. More of a safe fall-back than the most secure solution (server should update CA accordingly and the flag should not be requried)