### PR TITLE
Makefile: Add `nonfree` repo to fix model fetching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,6 @@ CACHED_MODEL ?= true
 models/s27ks0641:
 	mkdir -p $@
 	rm -rf model_tmp && mkdir model_tmp
-ifneq (,$(wildcard /etc/iis.version))
-	@$(MAKE) hyper-nonfree-init
-endif
 	@if [ -f "nonfree/nonfree.mk" ]; then \
 		[ "$(CACHED_MODEL)" = "false" ] && $(MAKE) fetch-model; \
 		cp nonfree/cached/*.zip model_tmp/; \

--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,39 @@ sim_clean:
 	rm -rf scripts/compile.tcl
 	rm -rf work
 
-# Download (partially non-free) simulation models from publically available sources;
-# by running these targets or targets depending on them, you accept this (see README.md).
+# Nonfree components. As observed from July 15th, 2025, Infineon requires SSO
+# authentication to get the model. For internal usage, we support fetching the
+# model from a cached location, or automatically downloading it, through the
+# variable `CACHED_MODEL`, default to `true`. However, open-source users must
+# manually download the models with their credentials.
+HYPER_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:pulp-restricted/hyperbus-nonfree.git
+HYPER_NONFREE_COMMIT ?= fba6af4
+
+.PHONY: hyper-nonfree-init
+hyper-nonfree-init:
+	git clone $(HYPER_NONFREE_REMOTE) nonfree
+	cd nonfree && git checkout $(HYPER_NONFREE_COMMIT)
+
+-include nonfree/nonfree.mk
+CACHED_MODEL ?= true
+
 models/s27ks0641:
 	mkdir -p $@
 	rm -rf model_tmp && mkdir model_tmp
-	cd model_tmp; wget --no-check-certificate --content-disposition "https://www.infineon.com/dgdl/Infineon-S27KL0641_S27KS0641_VERILOG-SimulationModels-v05_00-EN.zip?fileId=8ac78c8c7d0d8da4017d0f6349a14f68&da=t"
-	mv model_tmp/*.zip model_tmp/model.zip
-	cd model_tmp; unzip model.zip
+ifneq (,$(wildcard /etc/iis.version))
+	@$(MAKE) hyper-nonfree-init
+endif
+	@if [ -f "nonfree/nonfree.mk" ]; then \
+		[ "$(CACHED_MODEL)" = "false" ] && $(MAKE) fetch-model; \
+		cp nonfree/cached/*.zip model_tmp/; \
+	else \
+		echo "The model requires SSO authenatication for dowload. Download it manually from:"; \
+		echo "https://www.infineon.com/dgdl/Infineon-S27KL0641_S27KS0641_VERILOG-SimulationModels-v05_00-EN.zip?fileId=8ac78c8c7d0d8da4017d0f6349a14f68&da=t"; \
+		echo "Save the .zip file into: \`model_tmp\`"; \
+		read -p "Press enter once the file is placed in \`model_tmp\`..."; \
+	fi
+	mv model_tmp/*.zip model_tmp/model.zip; \
+	cd model_tmp; unzip -q model.zip
 	cd model_tmp; mv 'S27KL0641 S27KS0641' exe_folder
 	cd model_tmp/exe_folder; unzip S27ks0641.exe
 	cp model_tmp/exe_folder/S27ks0641/model/s27ks0641.v $@

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ hyper-nonfree-init:
 
 -include nonfree/nonfree.mk
 CACHED_MODEL ?= true
+CACHED_MODEL_PATH ?=
 
 models/s27ks0641:
 	mkdir -p $@
@@ -63,10 +64,14 @@ models/s27ks0641:
 		[ "$(CACHED_MODEL)" = "false" ] && $(MAKE) fetch-model; \
 		cp nonfree/cached/*.zip model_tmp/; \
 	else \
-		echo "The model requires SSO authenatication for dowload. Download it manually from:"; \
-		echo "https://www.infineon.com/dgdl/Infineon-S27KL0641_S27KS0641_VERILOG-SimulationModels-v05_00-EN.zip?fileId=8ac78c8c7d0d8da4017d0f6349a14f68&da=t"; \
-		echo "Save the .zip file into: \`model_tmp\`"; \
-		read -p "Press enter once the file is placed in \`model_tmp\`..."; \
+		if ! ls $(CACHED_MODEL_PATH)/*.zip 1> /dev/null 2>&1; then \
+			echo "The model requires SSO authentication for download. Download it manually from:"; \
+			echo "https://www.infineon.com/dgdl/Infineon-S27KL0641_S27KS0641_VERILOG-SimulationModels-v05_00-EN.zip?fileId=8ac78c8c7d0d8da4017d0f6349a14f68&da=t"; \
+			echo "Save the .zip file into: \`model_tmp\`"; \
+			read -p "Press enter once the file is placed in \`model_tmp\`..."; \
+		else \
+			cp $(CACHED_MODEL_PATH)/*.zip model_tmp/; \
+		fi \
 	fi
 	mv model_tmp/*.zip model_tmp/model.zip; \
 	cd model_tmp; unzip -q model.zip

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ sim_clean:
 # variable `CACHED_MODEL`, default to `true`. However, open-source users must
 # manually download the models with their credentials.
 HYPER_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:pulp-restricted/hyperbus-nonfree.git
-HYPER_NONFREE_COMMIT ?= fba6af4
+HYPER_NONFREE_COMMIT ?= 7ccecccd
 
 .PHONY: hyper-nonfree-init
 hyper-nonfree-init:


### PR DESCRIPTION
* As observed from July 15th, 2025, Infineon requires SSO authentication to download the hyperram model files. Therefore, our current way of fetching the model is broken
* For internal usage, this PR adds support to fetch the model from a cached location, or automatically downloading it, through the variable `CACHED_MODEL`, default to `true`. 
* Open-source users must manually download the models with their credentials.
* `nonfree` reference PR: https://iis-git.ee.ethz.ch/pulp-restricted/hyperbus-nonfree/-/merge_requests/1

**Note:** the flow was successfully tested in-system in chimera: https://iis-git.ee.ethz.ch/github-mirror/chimera/-/pipelines  