### PR TITLE
hyperbus_axi: fix odd aligned 8/16-bit accesses

### DIFF
--- a/src/hyperbus_axi.sv
+++ b/src/hyperbus_axi.sv
@@ -306,8 +306,11 @@ module hyperbus_axi #(
     assign trans_o.write            = rr_out_req_write;
     assign trans_o.burst_type       = 1'b1;             // Wrapping bursts not (yet) supported
     assign trans_o.address_space    = addr_space_i;
-    assign trans_o.address          = (rr_out_req_ax.addr & ((32'b1 << addr_mask_msb_i) - 1)) >>
-                                      (NumPhys == 2 && phys_in_use_i ? 2 : 1);
+    assign trans_o.address          = (NumPhys == 2) ?
+                                      (phys_in_use_i ?
+                                       ((rr_out_req_ax.addr & ((32'b1 << addr_mask_msb_i) - 1)) >> 2) :
+                                       (((rr_out_req_ax.addr & ((32'b1 << addr_mask_msb_i) - 1)) >> 2) << 1)) :
+                                      ((rr_out_req_ax.addr & ((32'b1 << addr_mask_msb_i) - 1)) >> 1);
 
     // Convert burst length from decremented, unaligned beats to non-decremented, aligned 16-bit words
     always_comb begin

--- a/src/hyperbus_axi.sv
+++ b/src/hyperbus_axi.sv
@@ -306,7 +306,8 @@ module hyperbus_axi #(
     assign trans_o.write            = rr_out_req_write;
     assign trans_o.burst_type       = 1'b1;             // Wrapping bursts not (yet) supported
     assign trans_o.address_space    = addr_space_i;
-    assign trans_o.address          = ( (rr_out_req_ax.addr & ~32'(32'hFFFF_FFFF << addr_mask_msb_i)) >> ( NumPhys ) ) << ( (NumPhys==2) & ~phys_in_use_i );
+    assign trans_o.address          = (rr_out_req_ax.addr & ((32'b1 << addr_mask_msb_i) - 1)) >>
+                                      (NumPhys == 2 && phys_in_use_i ? 2 : 1);
 
     // Convert burst length from decremented, unaligned beats to non-decremented, aligned 16-bit words
     always_comb begin

--- a/src/hyperbus_pkg.sv
+++ b/src/hyperbus_pkg.sv
@@ -70,7 +70,7 @@ package hyperbus_pkg;
             t_read_write_recovery:      'h6,
             t_rx_clk_delay:             'h8,
             t_tx_clk_delay:             'h8,
-            address_mask_msb:           'd25,                // 26 bit addresses = 2^6*2^20B == 64 MB per chip (biggest availale as of now)
+            address_mask_msb:           'd25,                // 2^(address mask MSB) = single chip size [bytes]
             address_space:              'b0,
             phys_in_use:                NumPhys-1,
             which_phy:                  NumPhys-1,

--- a/test/axi_hyper_tb.sv
+++ b/test/axi_hyper_tb.sv
@@ -92,6 +92,15 @@ module axi_hyper_tb
     .TT( TbTestTime         )
   ) axi_scoreboard_mst_t;
 
+  typedef axi_test::axi_driver #(
+    .AW ( TbAxiAddrWidthFull ),
+    .DW ( TbAxiDataWidthFull ),
+    .IW ( TbAxiIdWidthFull   ),
+    .UW ( TbAxiUserWidthFull ),
+    .TA ( TbApplTime         ),
+    .TT ( TbTestTime         )
+  ) axi_driver_t;
+
   typedef reg_test::reg_driver #(
     .AW ( RegBusAW   ),
     .DW ( RegBusDW   ),
@@ -133,17 +142,112 @@ module axi_hyper_tb
 
   logic s_error;
   logic [31:0] reg_read;
+
+  function automatic logic [TbAxiDataWidthFull/8-1:0] subword_strb(
+    input axi_addr_t addr,
+    input int unsigned size
+  );
+    automatic int unsigned num_bytes = 1 << size;
+    automatic logic [TbAxiDataWidthFull/8-1:0] strb = '0;
+    for (int unsigned i = 0; i < num_bytes; i++) begin
+      strb[addr[$clog2(TbAxiDataWidthFull/8)-1:0] + i] = 1'b1;
+    end
+    return strb;
+  endfunction
+
+  function automatic logic [TbAxiDataWidthFull-1:0] subword_data(
+    input logic [TbAxiDataWidthFull-1:0] data,
+    input axi_addr_t addr
+  );
+    return data << (8 * addr[$clog2(TbAxiDataWidthFull/8)-1:0]);
+  endfunction
+
+  task automatic axi_write_subword(
+    input axi_driver_t axi_drv,
+    input axi_addr_t addr,
+    input logic [TbAxiDataWidthFull-1:0] data,
+    input int unsigned size
+  );
+    axi_driver_t::ax_beat_t ax = new();
+    axi_driver_t::w_beat_t w = new();
+    axi_driver_t::b_beat_t b;
+
+    ax.ax_addr  = addr;
+    ax.ax_id    = '0;
+    ax.ax_len   = '0;
+    ax.ax_size  = size;
+    ax.ax_burst = axi_pkg::BURST_INCR;
+    axi_drv.send_aw(ax);
+
+    w.w_data = subword_data(data, addr);
+    w.w_strb = subword_strb(addr, size);
+    w.w_last = 1'b1;
+    axi_drv.send_w(w);
+    axi_drv.recv_b(b);
+    if (b.b_resp != axi_pkg::RESP_OKAY) begin
+      $error("[AXI] Write to 0x%08x returned response %0d", addr, b.b_resp);
+    end
+  endtask
+
+  task automatic axi_check_subword(
+    input axi_driver_t axi_drv,
+    input axi_addr_t addr,
+    input logic [TbAxiDataWidthFull-1:0] expected,
+    input int unsigned size
+  );
+    axi_driver_t::ax_beat_t ax = new();
+    axi_driver_t::r_beat_t r;
+    logic [TbAxiDataWidthFull-1:0] mask;
+    logic [TbAxiDataWidthFull-1:0] actual;
+    int unsigned num_bytes;
+
+    ax.ax_addr  = addr;
+    ax.ax_id    = '0;
+    ax.ax_len   = '0;
+    ax.ax_size  = size;
+    ax.ax_burst = axi_pkg::BURST_INCR;
+    axi_drv.send_ar(ax);
+    axi_drv.recv_r(r);
+
+    num_bytes = 1 << size;
+    mask = '0;
+    for (int unsigned i = 0; i < num_bytes; i++) begin
+      mask[i*8 +: 8] = 8'hff;
+    end
+    actual = r.r_data >> (8 * addr[$clog2(TbAxiDataWidthFull/8)-1:0]);
+
+    if (r.r_resp != axi_pkg::RESP_OKAY || (actual & mask) != (expected & mask)) begin
+      $error("[AXI] Read from 0x%08x returned 0x%016x, expected 0x%016x, response %0d",
+             addr, actual & mask, expected & mask, r.r_resp);
+    end
+  endtask
+
+  task automatic check_odd_subword_accesses(input axi_driver_t axi_drv);
+    localparam axi_addr_t BaseAddr = axi_addr_t'(32'h8000_0100);
+
+    axi_write_subword(axi_drv, BaseAddr + 32'h0, 64'h0000_0000_0000_1234, 1);
+    axi_write_subword(axi_drv, BaseAddr + 32'h2, 64'h0000_0000_0000_abcd, 1);
+    axi_check_subword(axi_drv, BaseAddr + 32'h0, 64'h0000_0000_0000_1234, 1);
+    axi_check_subword(axi_drv, BaseAddr + 32'h2, 64'h0000_0000_0000_abcd, 1);
+
+    axi_write_subword(axi_drv, BaseAddr + 32'h4, 64'h0000_0000_0000_005a, 0);
+    axi_write_subword(axi_drv, BaseAddr + 32'h5, 64'h0000_0000_0000_00c3, 0);
+    axi_check_subword(axi_drv, BaseAddr + 32'h4, 64'h0000_0000_0000_005a, 0);
+    axi_check_subword(axi_drv, BaseAddr + 32'h5, 64'h0000_0000_0000_00c3, 0);
+  endtask
      
   initial begin : proc_sim_crtl
 
     automatic axi_scoreboard_mst_t   mst_scoreboard  = new( score_mst_intf_dv );
     automatic axi_rand_master_t      axi_master      = new( axi_mst_intf_dv   );
+    automatic axi_driver_t           axi_driver      = new( axi_mst_intf_dv   );
     automatic reg_bus_master_t       reg_master      = new( reg_bus_mst       );
 
     // Reset the AXI drivers and scoreboards
     end_of_sim = 1'b0;
     mst_scoreboard.reset();
     axi_master.reset();
+    axi_driver.reset_master();
     reg_master.reset_master();
 
     // Set some mem regions for rand axi master
@@ -181,6 +285,8 @@ module axi_hyper_tb
        if (s_reg_error != 1'b0) $error("unexpected error");
 
        axi_master.reset();
+       axi_driver.reset_master();
+       check_odd_subword_accesses(axi_driver);
 
        $display("===========================");
        $display("= Random AXI transactions =");
@@ -202,6 +308,8 @@ module axi_hyper_tb
        if (s_reg_error != 1'b0) $error("unexpected error");
 
        axi_master.reset();
+       axi_driver.reset_master();
+       check_odd_subword_accesses(axi_driver);
 
        $display("===========================");
        $display("= Random AXI transactions =");

--- a/test/dut_if.sv
+++ b/test/dut_if.sv
@@ -198,7 +198,8 @@ module dut_if
        for (genvar p=0; p<NumPhys; p++) begin : sdf_annotation
           for (genvar l=0; l<NumChips; l++) begin : sdf_annotation
              initial begin
-                automatic string sdf_file_path = "./models/s27ks0641/s27ks0641.sdf";
+                string sdf_file_path;
+                sdf_file_path = "./models/s27ks0641/s27ks0641.sdf";
                 $sdf_annotate(sdf_file_path, hyperrams[p].chips[l].dut);
                 $display("Mem (%d,%d)",p,l);
              end

--- a/test/fixture_hyperbus.sv
+++ b/test/fixture_hyperbus.sv
@@ -431,9 +431,9 @@ module fixture_hyperbus #(
               if(clear)
                 w_beat.w_data = '1;
               else
-                randomize(w_beat.w_data);
+                w_beat.w_data = {$urandom(), $urandom()};
               axi_master_drv.send_w(w_beat);
-              trans_wdata = '1; //the memory regions where we do not write are have all ones in the hyperram.
+              trans_wdata = '1; // Unwritten memory regions are initialized to all ones in the HyperRAM.
               `ifdef AXI_VERBOSE
               $display("%p", w_beat);
               $display("%x", w_beat.w_data);


### PR DESCRIPTION
When `NumPhys=2` and `phys_in_use=0`, the address forwarded to the PHY is computed as `>> 2` followed by `<< 1`. These two operations do not cancel: the right shift discards bit [1] of the byte address before the left shift can restore it, making the result inequivalent to a simple `>> 1`.
This means that for any AXI transaction smaller than 32 bits (i.e. 16-bit or 8-bit sized accesses), the least significant word-address bit is silently zeroed, causing every odd-aligned 16-bit word to alias to the even-aligned word below it.

Additionally, I think a comment has to be fixed in the package regarding the value of `addr_mask_msb`. Its value should satisfy the equation: `2^(addr_mask_msb) = single chip size [bytes]`. However, now it implies `2^(addr_mask_msb + 1) = single chip size [bytes]`.